### PR TITLE
Adds !r conversion flag to line 1

### DIFF
--- a/ex8.py
+++ b/ex8.py
@@ -1,4 +1,4 @@
-formatter = "{} {} {} {}"
+formatter = "{!r} {!r} {!r} {!r}"
 
 print(formatter.format(1, 2, 3, 4))
 print(formatter.format("one", "two", "three", "four"))


### PR DESCRIPTION
Study drill two in this exercise relies, as currently formatted, on the use of the original %r format string. This commit proposes to use the !r conversion flag available in Python 3.6 to replicate this behaviour and allow study drill 2 to be kept in it's current form as it is a useful drill to learn.

This change also supports a proposed change/request for clarification regarding exercise 6 (which I won't list here as this pull request doesn't close it) which seeks to introduce the use of conversion flags early in the course.